### PR TITLE
feat: change when `build-and-deploy` runs

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,6 +4,12 @@ name: Deploy blog to GitHub Pages
 on:
   push:
     branches: ["main"]
+    paths:
+      - "content/**"
+      - "pelicanconf.py"
+      - "poetry.local"
+      - "publishconfig.py"
+      - "pyproject.toml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The workflow responsible for building and deploying the blog will now only run providing pushes involve changes to specific files. Commits that only involve changes to files not listed under `paths` are not expected to require a build and deploy of the blog.